### PR TITLE
Prevent facets to disappear if no products found

### DIFF
--- a/code/helpers/FacetHelper.php
+++ b/code/helpers/FacetHelper.php
@@ -225,7 +225,7 @@ class FacetHelper extends Object
     public function buildFacets(SS_List $matches, array $facetSpec, $autoFacetAttributes=false)
     {
         $facets = $this->expandFacetSpec($facetSpec);
-        if (!$autoFacetAttributes && (empty($facets) || !$matches || !$matches->count())) {
+        if (!$autoFacetAttributes && (empty($facets) || !$matches)) {
             return new ArrayList();
         }
         $fasterMethod = (bool)$this->config()->faster_faceting;


### PR DESCRIPTION
I don't think it's a good idea to destroy all facets if there is no matching products. I.e user unchecked all categories. This is normal case and should not ruin whole sidebar.
